### PR TITLE
Copy fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boostbank/stateful",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Global State Management JS",
   "main": "lib/index.js",
   "scripts": {

--- a/src/deep-copy.js
+++ b/src/deep-copy.js
@@ -1,0 +1,23 @@
+const deepCopy = item =>{
+    let copy = item;
+    if(item !== undefined && item !== null){
+        if(Array.isArray(item)){
+            copy = [];
+            for (let i = 0; i < item.length; i++) {
+                const potentialItem = item[i];
+                copy.push(deepCopy(potentialItem));
+            }
+        }
+        else if(typeof item === "object"){
+            const keys = Object.keys(item);
+            copy = {};
+            for (let i = 0; i < keys.length; i++) {
+                const key = keys[i];
+                copy[key] = deepCopy(item[key]);
+            }
+        }
+    }
+    return copy;
+};
+
+module.exports = deepCopy;

--- a/src/stateful.js
+++ b/src/stateful.js
@@ -61,7 +61,7 @@ const notifyOne = (subscriber, currentStore, modifyCallback, who) =>{
  */
 class Stateful {
   constructor() {
-    this.currentStore = undefined;
+    this.currentStore = {};
     this.maxDepth = -1;
     this.subscribers = [];
     this.states = [];

--- a/src/stateful.js
+++ b/src/stateful.js
@@ -7,7 +7,7 @@ const NUMBER = "number";
 const STRING = "string";
 const UNDEFINED = "undefined";
 
-const copy = require('./copy');
+const deepCopy = require('./deep-copy');
 
 let instance = undefined;
 
@@ -83,7 +83,7 @@ class Stateful {
    */
   createStore(store = {}, maxDepth = 0) {
     if (this.currentStore === undefined) {
-      this.currentStore = copy(store);
+      this.currentStore = deepCopy(store);
       this.maxDepth = maxDepth;
       pushToStack(this.states, this.maxDepth, this.currentStore);
     }
@@ -133,8 +133,8 @@ class Stateful {
         newState !== null &&
         typeof newState === OBJECT
       ) {
-        this.currentStore = newState;
-        notify(this.subscribers, copy(this.currentStore), modifyCallback, who);
+        this.currentStore = deepCopy(newState);
+        notify(this.subscribers, deepCopy(this.currentStore), modifyCallback, who);
         pushToStack(this.states, this.maxDepth, this.currentStore);
       }
     }
@@ -190,7 +190,7 @@ class Stateful {
    * Get entire state.
    */
   getState() {
-    return copy(this.currentStore);
+    return deepCopy(this.currentStore);
   }
 }
 

--- a/src/stateful.js
+++ b/src/stateful.js
@@ -44,7 +44,7 @@ const pushToStack = (states, maxDepth, newState) => {
 
 const notify = (subscribers, currentStore, modifyCallback, who) => {
   for(let i = subscribers.length - 1; i >= 0; i--){
-    subscribers[i](currentStore, whoWasModified=>{
+    subscribers[i](deepCopy(currentStore), whoWasModified=>{
       if(who === whoWasModified){
         modifyCallback();
       }
@@ -53,7 +53,7 @@ const notify = (subscribers, currentStore, modifyCallback, who) => {
 };
 
 const notifyOne = (subscriber, currentStore, modifyCallback, who) =>{
-  notify([subscriber], currentStore, modifyCallback, who);
+  notify([subscriber], deepCopy(currentStore), modifyCallback, who);
 };
 
 /**
@@ -134,7 +134,7 @@ class Stateful {
         typeof newState === OBJECT
       ) {
         this.currentStore = deepCopy(newState);
-        notify(this.subscribers, deepCopy(this.currentStore), modifyCallback, who);
+        notify(this.subscribers, this.currentStore, modifyCallback, who);
         pushToStack(this.states, this.maxDepth, this.currentStore);
       }
     }

--- a/tests/Stateful.test.js
+++ b/tests/Stateful.test.js
@@ -85,7 +85,7 @@ describe("Stateful Tests", () => {
     stateful.rollback();
     expect(stateful.getState().test).toBe("test");
     stateful.rollback();
-    expect(stateful.getState().test).toBe("test");
+    expect(stateful.getState().test).toBe(undefined);
   });
 
   it("Should rollback the state async", done => {

--- a/tests/copy.test.js
+++ b/tests/copy.test.js
@@ -1,0 +1,28 @@
+const copy = require('./../src/copy');
+
+describe("Stateful Tests", () => {
+    beforeEach(() => {
+      
+    });
+
+    it("Should copy an object.", ()=>{
+
+        const toCopy = {message: "Hello", time: 1, other: {test: true}};
+
+        const copied = copy(toCopy);
+
+        expect(copied).not.toBe(toCopy);
+        expect(copied.other).toBe(toCopy.other);
+    });
+
+    
+    it("Should not copy an array.", ()=>{
+        const toCopy = {message: "Hello", time: 1, other: [1,2,3]};
+
+        const copied = copy(toCopy);
+
+        expect(copied).not.toBe(toCopy);
+        expect(copied.other).toBe(toCopy.other);
+    });
+
+});

--- a/tests/deep-copy.test.js
+++ b/tests/deep-copy.test.js
@@ -42,7 +42,6 @@ describe("Stateful Tests", () => {
 
     it("Should not copy a function.", ()=>{
         const func = (test)=>{};
-        console.log(func);
         const copied = deepCopy(func);
         expect(copied).toBe(func);
     });

--- a/tests/deep-copy.test.js
+++ b/tests/deep-copy.test.js
@@ -40,4 +40,11 @@ describe("Stateful Tests", () => {
         expect(copied).toBe(undefined);
     });
 
+    it("Should not copy a function.", ()=>{
+        const func = (test)=>{};
+        console.log(func);
+        const copied = deepCopy(func);
+        expect(copied).toBe(func);
+    });
+
 });

--- a/tests/deep-copy.test.js
+++ b/tests/deep-copy.test.js
@@ -1,0 +1,43 @@
+const deepCopy = require('./../src/deep-copy');
+
+describe("Stateful Tests", () => {
+    beforeEach(() => {
+      
+    });
+
+    it("Should copy a object recursively.", ()=>{
+        const toCopy = {message: "Hello", time: 1, other: [1,2,3], two: {name: "test", another: {three: "test"}}};
+
+        const copied = deepCopy(toCopy);
+
+        expect(copied).not.toBe(toCopy);
+        expect(copied.other).not.toBe(toCopy.other);
+        expect(copied.two).not.toBe(toCopy.two);
+        expect(copied.two.another).not.toBe(toCopy.two.another);
+        expect(copied.two.another.three).toBe(toCopy.two.another.three);
+    });
+
+    
+    it("Should copy an array recursively.", ()=>{
+        const obj = {message: "Hello", time: 0, testing: true};
+        const toCopy = [obj]
+
+        const copied = deepCopy(toCopy);
+
+        expect(copied).not.toBe(toCopy);
+        expect(copied[0]).not.toBe(obj);
+        expect(copied[0].time).toBe(obj.time);
+    });
+
+    it("Should not copy null.", ()=>{
+        const copied = deepCopy(null);
+        expect(copied).toBe(null);
+    });
+
+    
+    it("Should not copy undefined.", ()=>{
+        const copied = deepCopy(undefined);
+        expect(copied).toBe(undefined);
+    });
+
+});


### PR DESCRIPTION
#4 Fixes incoming. Now deep copies all objects when its stored and retrieved.

- Also fixes with possible memory leaks when subscribers received the same copy of an object. Now each subscriber gets their own copy.

- Fixes with possible memory leak when getting a subStores state with the function `getSubState();`